### PR TITLE
Fix TranslateFileToFileParams force type

### DIFF
--- a/src/nlingua2/models.py
+++ b/src/nlingua2/models.py
@@ -29,4 +29,4 @@ class TranslateFileToFileParams:
     output: Path
     src_lang: str
     tgt_lang: str
-    force: str
+    force: bool


### PR DESCRIPTION
## Summary
- fix incorrect dataclass type for TranslateFileToFileParams.force

## Testing
- `ruff check src/nlingua2/models.py`
- `pyright src/nlingua2/models.py`


------
https://chatgpt.com/codex/tasks/task_e_683fccacd7fc8329ba2af29ba2cf4bac