### PR TITLE
Fix Ruff N818 naming for exception classes

### DIFF
--- a/src/nlingua2/cli.py
+++ b/src/nlingua2/cli.py
@@ -3,9 +3,9 @@ import sys
 from pathlib import Path
 
 from nlingua2.exceptions import (
-    InvalidLanguageException,
-    SubRipNotValidException,
-    TimecodeException,
+    InvalidLanguageError,
+    SubRipNotValidError,
+    TimecodeError,
 )
 from nlingua2.models import TranslateFileToFileParams
 from nlingua2.runner import transcribe_from_file_to_file, translate_from_file_to_file
@@ -146,10 +146,10 @@ def main() -> None:
                 )
         else:
             parser.print_help()
-    except (SubRipNotValidException, TimecodeException) as e:
+    except (SubRipNotValidError, TimecodeError) as e:
         print(f"\n🔴 Error with SRT file: {e}\n")
         sys.exit(2)
-    except InvalidLanguageException as e:
+    except InvalidLanguageError as e:
         print(f"\n🔴 Language error: {e}\n")
         sys.exit(3)
     except (FileNotFoundError, FileExistsError) as e:

--- a/src/nlingua2/exceptions.py
+++ b/src/nlingua2/exceptions.py
@@ -1,10 +1,10 @@
-class TimecodeException(Exception):
+class TimecodeError(Exception):
     pass
 
 
-class SubRipNotValidException(Exception):
+class SubRipNotValidError(Exception):
     pass
 
 
-class InvalidLanguageException(Exception):
+class InvalidLanguageError(Exception):
     pass

--- a/src/nlingua2/parser.py
+++ b/src/nlingua2/parser.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from nlingua2.exceptions import SubRipNotValidException
+from nlingua2.exceptions import SubRipNotValidError
 from nlingua2.factories import create_subrip_entry
 from nlingua2.models import SubRipEntry
 from nlingua2.translator import translate
@@ -10,7 +10,7 @@ from nlingua2.utils import DOUBLE_EOL_RE, EOL_RE
 def subrip_text_to_entries(subrip: str) -> list[SubRipEntry]:
     if not subrip.strip():
         msg = "Input .srt file is empty or only whitespace."
-        raise SubRipNotValidException(msg)
+        raise SubRipNotValidError(msg)
 
     subrip_entry_lines = DOUBLE_EOL_RE.split(subrip)
     entries: list[SubRipEntry] = []

--- a/src/nlingua2/utils.py
+++ b/src/nlingua2/utils.py
@@ -1,6 +1,6 @@
 import re
 
-from nlingua2.exceptions import TimecodeException
+from nlingua2.exceptions import TimecodeError
 from nlingua2.settings import WHISPER_AND_NLLB_LANGUAGES
 
 TIMECODE_RE = re.compile(
@@ -18,7 +18,7 @@ def get_subrip_timecodes_or_fail(text: str) -> tuple[str, str]:
 
     if matches is None:
         msg = f"Invalid timecodes for: {text}"
-        raise TimecodeException(msg)
+        raise TimecodeError(msg)
 
     return matches.group(1), matches.group(2)
 

--- a/src/nlingua2/validation.py
+++ b/src/nlingua2/validation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from nlingua2.exceptions import InvalidLanguageException
+from nlingua2.exceptions import InvalidLanguageError
 from nlingua2.models import TranslateFileToFileParams
 from nlingua2.settings import WHISPER_AND_NLLB_LANGUAGES
 
@@ -26,7 +26,7 @@ def validate_nllb_language(lang: str) -> None:
             f"Invalid NLLB language: {lang}. "
             "Use `nlingua2 nllb_languages` to see available languages."
         )
-        raise InvalidLanguageException(msg)
+        raise InvalidLanguageError(msg)
 
 
 def validate_whisper_language(lang: str) -> None:
@@ -35,7 +35,7 @@ def validate_whisper_language(lang: str) -> None:
             f"Invalid Whisper language: {lang}. "
             "Use `nlingua2 whisper_languages` to see available languages."
         )
-        raise InvalidLanguageException(msg)
+        raise InvalidLanguageError(msg)
 
 
 def validate_from_file_to_file(


### PR DESCRIPTION
## Summary
- rename custom exception classes to end with `Error` to satisfy Ruff

## Testing
- `ruff check .`
- `pyright` *(fails: Import errors from missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fed140020832988ec64a5dff3a37d